### PR TITLE
Do not return absolute, but relative locations.

### DIFF
--- a/routers/bucket/file-upload.js
+++ b/routers/bucket/file-upload.js
@@ -14,7 +14,7 @@ module.exports = (storage) => {
   ];
 
   router.post('/', handlers, (req, res) => {
-    let reqUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+    let reqUrl = req.originalUrl;
     if (reqUrl[reqUrl.length - 1] != '/'){
       reqUrl += '/';
     }


### PR DESCRIPTION
By default, the client is responsible of knowing where to get the
file back on GET (on which host/port, that means).