### PR TITLE
feat: presigned upload URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ means in practice.
   top-level `await`, which is the only thing that would prevent it. A dynamic
   `import()` works too.
 
+* **Presigned uploads.** A new `presign-upload` action hands the caller a
+  short-lived signed URL it PUTs the bytes to directly, so they never pass
+  through Seshat. S3 and GCS only; `LocalBucket` refuses with 501. Opt-in:
+  `ExecuteActions` takes an explicit action list, so no existing deployment
+  gains it by upgrading. See the README for the two things it costs — content
+  transformers cannot run, and the `stored` event does not fire. Custom
+  metadata must be string-valued, and never overrides the object key, content
+  type or content length.
+
+* `Bucket` gains a required `presignUpload` member. This breaks anyone
+  implementing the interface directly rather than extending `AbstractBucket`,
+  which supplies a working implementation.
+
+* New `ObjectMetaTransformer` extension point. A transformer that implements
+  `transformMeta` declares itself metadata-only and may run at presign time;
+  one that does not is treated as content-touching and makes presigning refuse.
+  `SecureRename` now implements it. This is additive — existing third-party
+  transformers keep working, and default to the safe answer.
+
+* `S3BucketConfig` gains an optional `presignClient`, for when the client used
+  to sign URLs must differ from the one doing reads and writes.
+
+* Fix: `mkdir`, `cleanup-ttl` and `download-archive` derived their paths from
+  the raw `req.path` and so carried the Express 5 mount-path bug fixed in the
+  routers — `POST /bucket//` addressed a `/` prefix rather than the root.
+
 * The exported `Object` and `ObjectMeta` types are renamed to `SeshatObject`
   and `SeshatObjectMeta`. `Object` shadowed the JavaScript global, which could
   break `Object.keys`/`Object.entries` in any module that imported it, and

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM node:22-alpine as builder
 WORKDIR /home/app
 
 COPY package*.json ./
-RUN npm install
+# --ignore-scripts because "prepare" builds, and at this layer the sources it
+# needs have not been copied yet. The build happens explicitly below instead.
+RUN npm install --ignore-scripts
 
 COPY ./ ./
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,56 @@ Please have a look at the [examples/](examples/) folder, you'll find simple exam
 * [scan files for viruses using clamav](examples/clamav.ts)
 * [encrypt files using SSE-C](examples/sse-c.ts)
 * [execute actions such as creating empty prefixes and extract objects as zip files](examples/actions.ts)
+* [hand out presigned URLs so clients upload straight to storage](examples/presigned-upload.ts)
+
+# Presigned uploads
+
+A presigned upload hands the caller a short-lived URL it `PUT`s the bytes to
+directly. The bytes never pass through Seshat, which is worth doing for large
+files, or when whoever holds them — a browser, an agent on someone's laptop —
+can make an HTTP request but must not be given bucket credentials.
+
+Enable it by adding the action to a bucket's routers:
+
+```ts
+createApp({
+  bucket: new S3Bucket({ s3client, bucket: 'my-bucket', transformers: [new SecureRename()] }),
+  routers: [ExecuteActions([PresignUploadAction]), RetrieveObjects(), ListObjects()],
+});
+```
+
+No existing deployment gains presigning by upgrading: `ExecuteActions` takes an
+explicit list.
+
+**Two things it costs you.** Content transformers cannot run — Seshat never sees
+the bytes, so it cannot scan, resize or compress them. A bucket configured with
+one refuses to presign rather than quietly dropping the guarantee; name-only
+transformers such as `SecureRename` still apply. And the `stored` event does not
+fire, because this process never learns whether the upload happened; callers
+that need to know should `HEAD` the object afterwards using the returned `name`.
+
+**What the signature binds:** the object key, the exact content length, the
+content type, and any custom metadata. A holder of the URL can write that one
+object, at that size and type, until it expires — and nothing else.
+
+Custom metadata values must be strings, and are stored as backend custom
+metadata under whatever keys you give. They never override the object key,
+content type or content length — those come from the request path and the
+validated request body, so a `metadata` entry cannot move the object or widen
+the size the action approved.
+
+**Backends.** S3 and GCS only. `LocalBucket` refuses with `501`: a filesystem has
+no signing authority.
+
+**An S3 client used for presigning must be built with
+`requestChecksumCalculation: 'WHEN_REQUIRED'`.** Left at its default the SDK
+computes a checksum of the request body and the signer binds it into the URL —
+but the body is empty at signing time, so the upload is rejected on arrival.
+Seshat refuses to presign with such a client rather than handing out URLs that
+fail later. Pass `presignClient` when the signing client has to differ from the
+one doing ordinary reads and writes, which is also what you need when storage
+sits behind a private network: the signature covers the `Host` header, so the URL
+must name an address its holder can actually reach.
 
 # Installing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     command: npm run dev
     environment:
       S3_ENDPOINT: https://minio
+      # Presigned URLs are consumed by the client, not by this process, so they
+      # must be signed against an address the client can actually reach - the
+      # signature covers the Host header, so the two cannot differ.
+      S3_PUBLIC_ENDPOINT: https://127.0.0.1:9000
       # we are using self signed certs in development/test
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
     ports:
@@ -17,7 +21,11 @@ services:
   minio:
     image: minio/minio
     ports:
-      - 9000:9000
+      # minio listens on 443 (see --address below), so the old 9000:9000
+      # mapping pointed at a port nothing was bound to and minio was simply
+      # unreachable from the host. The presigned-upload round trip needs to
+      # reach it from outside the network, since that is where the client is.
+      - 9000:443
       - 9001:9001
     environment:
       MINIO_ACCESS_KEY: access-key

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -13,6 +13,7 @@ import actionsExample from './actions.js';
 import sseExample from './sse-c.js';
 import clamavExample from './clamav.js';
 import cacheControlExample from './cacheControl.js';
+import presignedUploadExample from './presigned-upload.js';
 
 import { version } from '../src/index.js';
 import logger from '../src/logger.js';
@@ -35,6 +36,7 @@ app.set('etag', 'strong');
   sseExample,
   clamavExample,
   cacheControlExample,
+  presignedUploadExample,
 ].forEach((example) => example(app, process.env.ROOT_DIR || '../'));
 
 app.listen(3000, () => {

--- a/examples/presigned-upload.ts
+++ b/examples/presigned-upload.ts
@@ -1,0 +1,83 @@
+import { type Express } from 'express';
+import { S3Client } from '@aws-sdk/client-s3';
+import { createApp, S3Bucket } from '../src/index.js';
+import { s3client } from './s3.js';
+import { ExecuteActions, RetrieveObjects, ListObjects } from '../src/express/routers/index.js';
+import { PresignUploadAction } from '../src/actions/index.js';
+import { SecureRename } from '../src/transformers/index.js';
+
+/**
+ * Presigned uploads: the client PUTs its bytes straight at the storage backend,
+ * so they never travel through this process at all.
+ *
+ * Worth uploading a file that way when it is large, or when whoever holds the
+ * bytes (a browser, an agent on someone's laptop) can make an HTTP request but
+ * must not be handed bucket credentials.
+ *
+ * Two consequences to weigh before reaching for it:
+ *
+ *   - Transformers that rewrite content cannot run. Seshat never sees the bytes,
+ *     so it cannot scan, resize or compress them. A bucket carrying such a
+ *     transformer refuses to presign rather than quietly dropping the guarantee.
+ *     Name-only transformers such as SecureRename are fine, and still apply.
+ *
+ *   - The `stored` event does not fire, because this process never learns
+ *     whether the upload happened. Callers that need to know should HEAD the
+ *     object afterwards, using the `name` the presign response returned.
+ *
+ * Two legs:
+ *
+ *   curl -X POST http://localhost:3000/presigned/ \
+ *     -H 'content-type: application/vnd.seshat-action+json' \
+ *     -H 'seshat-action: presign-upload' \
+ *     -d '{"filename":"report.pdf","contentType":"application/pdf","contentLength":4823910}'
+ *
+ * then, with the url and headers that came back:
+ *
+ *   curl -X PUT "<url>" \
+ *     -H 'content-type: application/pdf' \
+ *     -H 'content-length: 4823910' \
+ *     --data-binary @report.pdf
+ */
+export default (expressApp: Express) => {
+
+  expressApp.use('/presigned', createApp({
+    bucket: new S3Bucket({
+      // reads and writes go over the network this process sits on...
+      s3client,
+      // ...while the signed URL has to name an address its holder can reach
+      presignClient: presignableClient,
+      bucket: 'my-s3-bucket',
+      transformers: [new SecureRename()],
+    }),
+    routers: [
+      ExecuteActions([PresignUploadAction]),
+      RetrieveObjects(),
+      ListObjects(),
+    ],
+  }));
+
+};
+
+/**
+ * Note `requestChecksumCalculation`. Left at its default the SDK computes a
+ * checksum of the request body and the signer binds it into the URL - but at
+ * signing time that body is empty, so the checksum describes nothing and the
+ * real upload is rejected on arrival. A bucket given a client without this
+ * setting refuses to presign rather than handing out URLs that fail later.
+ */
+export const presignableClient = new S3Client({
+  region: 'eu-west1',
+  credentials: {
+    accessKeyId: 'access-key',
+    secretAccessKey: 'secret-key',
+  },
+  // The endpoint here is the one the *client* will connect to, which is not
+  // necessarily the one this process uses. A signature covers the Host header,
+  // so signing against an address the client cannot reach produces a URL that
+  // is either unroutable or rejected. In docker that means the published
+  // address rather than the compose network name.
+  endpoint: process.env.S3_PUBLIC_ENDPOINT || process.env.S3_ENDPOINT || 'http://127.0.0.1:9000',
+  forcePathStyle: true,
+  requestChecksumCalculation: 'WHEN_REQUIRED',
+});

--- a/formaldoc/config.rb
+++ b/formaldoc/config.rb
@@ -14,6 +14,7 @@ Webspicy::Configuration.new(Path.dir) do |c|
   c.postcondition ExifMetadataIsPreserved
   c.postcondition IsValidZipFile
   c.postcondition NoCacheControlHeader
+  c.postcondition PresignedUploadRoundTrips
   c.postcondition Webspicy::Web::Specification::Post::LastModifiedCachingProtocol
   c.postcondition Webspicy::Web::Specification::Post::ETagCachingProtocol
 

--- a/formaldoc/schema.fio
+++ b/formaldoc/schema.fio
@@ -9,6 +9,14 @@ SeshatObject = {
   ...           :  String | Integer | Date
 }
 
+PresignedUpload = {
+  url       : String
+  method    : String
+  headers   : {...: String}
+  name      : String
+  expiresAt : String
+}
+
 Error = {
   code: String
   message: String

--- a/formaldoc/support/postconditions/presigned_upload_round_trips.rb
+++ b/formaldoc/support/postconditions/presigned_upload_round_trips.rb
@@ -1,0 +1,59 @@
+require 'net/http'
+require 'uri'
+
+##
+# Uploads real bytes to the signed URL and then fetches the object back through
+# Seshat.
+#
+# This is the only check that proves the signature is actually correct. A unit
+# test can assert that a URL was produced and that its query string looks right
+# while the backend would still reject the upload - the AWS SDK, left at its
+# defaults, binds a checksum of the empty signing-time body into the URL, and
+# nothing but a real PUT reveals it.
+#
+class PresignedUploadRoundTrips
+  include Webspicy::Specification::Post
+
+  MATCH = /The signed url accepts the bytes and the object is retrievable/
+
+  def self.match(service, descr)
+    return nil unless descr =~ MATCH
+    PresignedUploadRoundTrips.new
+  end
+
+  def check!
+    presigned = invocation.output
+    body = 'seshat presigned upload payload'
+
+    uri = URI(presigned[:url])
+    http = Net::HTTP.new(uri.host, uri.port)
+    if uri.scheme == 'https'
+      http.use_ssl = true
+      # minio runs with a self-signed cert in the compose stack
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+
+    put = Net::HTTP::Put.new(uri)
+    presigned[:headers].each { |name, value| put[name.to_s] = value }
+    put.body = body
+
+    response = http.request(put)
+    unless response.code.to_i == 200
+      raise "Signed PUT rejected with #{response.code}: #{response.body}"
+    end
+
+    # ...and the object is now readable through Seshat under the returned name.
+    base, _ = test_case.specification.instantiate_url(test_case.params)
+    object_url = invocation.client.config.host + base + presigned[:name]
+    fetched = client.api.get(object_url)
+
+    raise "Could not download #{presigned[:name]}: #{fetched.status}" unless fetched.status == 200
+
+    got = fetched.body.to_s
+    unless got == body
+      raise "Object content does not match what was uploaded: " \
+            "expected #{body.inspect} (#{body.bytesize}B), got #{got[0, 80].inspect} (#{got.bytesize}B)"
+    end
+  end
+
+end

--- a/formaldoc/test-suite/actions/presign-upload/post.yml
+++ b/formaldoc/test-suite/actions/presign-upload/post.yml
@@ -1,0 +1,66 @@
+---
+name: |-
+  POST /presigned/ - action "presign-upload"
+
+url: |-
+  /presigned/
+
+services:
+- method: |-
+    POST
+
+  description: |-
+    Hands back a short-lived signed URL that the caller PUTs the bytes to
+    directly, so they never pass through Seshat.
+
+  input_schema: |-
+    {
+      filename      :  String
+      contentType   :  String
+      contentLength :  Integer
+      expiresIn     :? Integer
+    }
+
+  output_schema: |-
+    PresignedUpload
+
+  error_schema: |-
+    Error
+
+  postconditions:
+    - The signed url accepts the bytes and the object is retrievable
+
+  examples:
+
+    - description: |-
+        when requested for an object
+      headers:
+        content-type: application/vnd.seshat-action+json
+        seshat-action: presign-upload
+      params:
+        filename: report.pdf
+        contentType: application/pdf
+        # must match the payload the postcondition uploads: the exact length is
+        # bound into the signature
+        contentLength: 31
+      expected:
+        status: 200
+
+  # Schema-violating input (a missing contentLength, say) is covered by unit
+  # tests rather than here: webspicy validates a counterexample's params against
+  # input_schema, so a case that omits a required attribute never reaches the
+  # server at all.
+  counterexamples:
+
+    - description: |-
+        when expiresIn exceeds the allowed maximum
+      headers:
+        content-type: application/vnd.seshat-action+json
+        seshat-action: presign-upload
+      params:
+        filename: report.pdf
+        contentType: application/pdf
+        contentLength: 31
+        expiresIn: 86400
+      expected:
+        status: 400

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1100.0",
         "@aws-sdk/lib-storage": "^3.1100.0",
+        "@aws-sdk/s3-request-presigner": "^3.1100.0",
         "@google-cloud/storage": "^7.21.0",
         "@types/clamscan": "^2.4.1",
         "body-parser": "^2.3.0",
@@ -309,6 +310,23 @@
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1100.0.tgz",
+      "integrity": "sha512-YXl2CNTJi9sCWCZufz4efHgYUrLSHg+b6NnbLbUZKXjazlcPjYRE8liZ50ckj7ZSVaB6LHY3C8/8Sz7CcrLkmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:watch": "mocha tests/helpers.ts 'tests/**/*.spec.ts' --watch --watch-files src/**/*.ts,tests/**/*.ts",
     "lint": "eslint src tests --ext ts",
     "preversion": "npm run build",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "keywords": [],
@@ -33,6 +34,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1100.0",
     "@aws-sdk/lib-storage": "^3.1100.0",
+    "@aws-sdk/s3-request-presigner": "^3.1100.0",
     "@google-cloud/storage": "^7.21.0",
     "@types/clamscan": "^2.4.1",
     "body-parser": "^2.3.0",

--- a/src/abstract-bucket.ts
+++ b/src/abstract-bucket.ts
@@ -1,7 +1,8 @@
 import EventEmitter from 'events';
 import { Readable } from 'stream';
-import { ObjectTransformerError, SeshatError } from './errors.js';
-import type { Bucket, BucketPolicy, SeshatObject, SeshatObjectMeta, ObjectTransformer, ObjectTransformerOutput, BucketConfig, ObjectTransformerMode, BucketEmitter, BucketEvent, ListOptions } from './types.js';
+import { ObjectTransformerError, PresignNotSupportedError, SeshatError } from './errors.js';
+import type { Bucket, BucketPolicy, SeshatObject, SeshatObjectMeta, ObjectTransformer, ObjectTransformerOutput, BucketConfig, ObjectTransformerMode, BucketEmitter, BucketEvent, ListOptions, PresignedUpload, PresignedUploadRequest } from './types.js';
+import { DefaultPresignExpiresIn, isMetaTransformer } from './types.js';
 import logger from './logger.js';
 
 export default abstract class AbstractBucket implements Bucket, BucketEmitter {
@@ -47,6 +48,66 @@ export default abstract class AbstractBucket implements Bucket, BucketEmitter {
   }
 
   abstract _put(stream: Readable, meta: SeshatObjectMeta): Promise<SeshatObjectMeta>;
+
+  /**
+   * Hands back a short-lived URL the caller PUTs the bytes to directly.
+   *
+   * The bytes never reach this process, which is the entire point and also the
+   * entire cost: nothing here can scan, resize or compress them. Policies still
+   * apply, and run against the pre-rename metadata exactly as put() does, so a
+   * policy sees the same input either way. Transformers are the part that
+   * cannot survive - see transformMetaOnly.
+   *
+   * Note that `stored` does not fire: this bucket never learns whether the
+   * upload happened.
+   */
+  async presignUpload(request: PresignedUploadRequest): Promise<PresignedUpload> {
+    const meta: SeshatObjectMeta = {
+      // Spread first, exactly as MultipartUpload does: custom metadata is
+      // caller-supplied, and letting it land on top would let a `name` entry
+      // move the object key out of the path the request addressed, or a
+      // `contentLength` entry replace the value the action just checked against
+      // its ceiling.
+      ...request.metadata,
+      name: request.name,
+      contentType: request.contentType,
+      contentLength: request.contentLength,
+    };
+
+    await this.ensurePolicies((policy: BucketPolicy) => policy.put(meta));
+    const transformed = await this.transformMetaOnly(meta, 'Ingress');
+
+    return this._presignUpload(transformed, request.expiresIn ?? DefaultPresignExpiresIn);
+  }
+
+  /**
+   * Runs the transformer chain in metadata-only mode, refusing outright on any
+   * transformer that rewrites content. Refusing is the point: silently skipping
+   * a Clamav or Sharp transformer would hand back a URL that bypasses a
+   * guarantee the bucket was configured to make.
+   */
+  private async transformMetaOnly(meta: SeshatObjectMeta, mode: ObjectTransformerMode): Promise<SeshatObjectMeta> {
+    return this.transformers
+      .filter(t => [mode, 'Duplex'].includes(t.type))
+      .reduce(async (previous: Promise<SeshatObjectMeta>, transformer: ObjectTransformer) => {
+        const current = await previous;
+        if (!isMetaTransformer(transformer)) {
+          throw new PresignNotSupportedError(
+            'Cannot presign uploads on a bucket configured with the content transformer ' +
+            `'${transformer.constructor.name}': the bytes never reach Seshat, so it cannot run.`);
+        }
+        return transformer.transformMeta(current, mode);
+      }, Promise.resolve(meta));
+  }
+
+  /**
+   * Concrete, not abstract, so a backend with no signing authority - LocalBucket
+   * - inherits the refusal without needing code of its own.
+   */
+  protected async _presignUpload(_meta: SeshatObjectMeta, _expiresIn: number): Promise<PresignedUpload> {
+    throw new PresignNotSupportedError(
+      `${this.constructor.name} does not support presigned uploads`);
+  }
 
   async delete(path: string): Promise<void> {
     await this.ensurePolicies((policy: BucketPolicy) => policy.delete(path));

--- a/src/actions/cleanup-ttl.ts
+++ b/src/actions/cleanup-ttl.ts
@@ -1,5 +1,6 @@
 import { type Request } from 'express';
 import { type Action } from '../types.js';
+import { requestPath } from '../utils/index.js';
 
 export type CleanupTTLOptions = {
   ttlMetadataKey: string
@@ -16,7 +17,7 @@ export const CleanupTTLFactory = (options: CleanupTTLOptions = DefaultOptions): 
 
       const recursive = req.body?.recursive || false;
 
-      const path = decodeURIComponent(req.path.substring(1));
+      const path = decodeURIComponent(requestPath(req).substring(1));
       const bucket = req.seshat.bucket;
 
       const objects = await bucket.list(path, { recursive });

--- a/src/actions/download-archive.ts
+++ b/src/actions/download-archive.ts
@@ -1,5 +1,6 @@
 import { type Request, type Response } from 'express';
 import { type Action } from '../types.js';
+import { requestPath } from '../utils/index.js';
 import JSZip from 'jszip';
 import { SeshatError } from '../errors.js';
 
@@ -57,7 +58,7 @@ export const DownloadArchiveActionFactory = (): Action => {
             return objects.concat(content);
           }, [] as Array<ObjectToExport>);
       } else {
-        const path = decodeURIComponent(req.path.substring(1));
+        const path = decodeURIComponent(requestPath(req).substring(1));
         const metas = await bucket.list(path, { recursive: true });
         objectsToExport = metas.map(m => ({ name: m.name }));
       }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,3 +1,4 @@
 export * from './mkdir.js';
 export * from './download-archive.js';
 export * from './cleanup-ttl.js';
+export * from './presign-upload.js';

--- a/src/actions/mkdir.ts
+++ b/src/actions/mkdir.ts
@@ -1,12 +1,13 @@
 import { type Request } from 'express';
 import { type Action } from '../types.js';
+import { requestPath } from '../utils/index.js';
 
 export const MkdirActionFactory = (): Action => {
   return {
     name: 'mkdir',
     run: async (req: Request): Promise<any> => {
 
-      const path = decodeURIComponent(req.path.substring(1));
+      const path = decodeURIComponent(requestPath(req).substring(1));
       const bucket = req.seshat.bucket;
 
       await bucket.mkdir(path);

--- a/src/actions/presign-upload.ts
+++ b/src/actions/presign-upload.ts
@@ -1,0 +1,110 @@
+import path from 'path';
+import { type Request } from 'express';
+import { DefaultPresignExpiresIn, type Action, type PresignedUpload } from '../types.js';
+import { SeshatError } from '../errors.js';
+import { requestPath } from '../utils/index.js';
+
+export class InvalidPresignRequestError extends SeshatError {
+  httpCode = 400;
+}
+
+export type PresignUploadOptions = {
+  /** Seconds granted when the caller does not ask for a specific lifetime. */
+  defaultExpiresIn: number
+  /** Seconds. Requests above this are refused, not quietly shortened. */
+  maxExpiresIn: number
+  /**
+   * Bytes. Undefined leaves the ceiling to the deployment - a reverse proxy, or
+   * the bucket's own limits. Set it here when the signed URL is the only thing
+   * standing between a caller and your storage bill.
+   */
+  maxContentLength?: number
+}
+
+const DefaultOptions: PresignUploadOptions = {
+  defaultExpiresIn: DefaultPresignExpiresIn,
+  maxExpiresIn: 3600,
+};
+
+const requireString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new InvalidPresignRequestError(`'${field}' is required and must be a non-empty string`);
+  }
+  return value;
+};
+
+/**
+ * Backends turn every metadata value into a string on the way out, and reach
+ * for `.toString()` to do it - which a null value answers with a TypeError, and
+ * a nested object with '[object Object]'. Neither belongs in a 500, so the
+ * contract the error message already stated is enforced here instead.
+ */
+const requireStringValues = (metadata: unknown): Record<string, string> | undefined => {
+  if (metadata === undefined) {
+    return undefined;
+  }
+  if (typeof metadata !== 'object' || metadata === null || Array.isArray(metadata)) {
+    throw new InvalidPresignRequestError('\'metadata\' must be an object of string values');
+  }
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value !== 'string') {
+      throw new InvalidPresignRequestError(
+        `'metadata.${key}' must be a string, got ${value === null ? 'null' : typeof value}`);
+    }
+  }
+  return metadata as Record<string, string>;
+};
+
+export const PresignUploadActionFactory = (options: PresignUploadOptions = DefaultOptions): Action => {
+  const config = { ...DefaultOptions, ...options };
+
+  return {
+    name: 'presign-upload',
+    run: async (req: Request): Promise<PresignedUpload> => {
+      const { filename, contentType, contentLength, expiresIn, metadata } = req.body || {};
+
+      requireString(filename, 'filename');
+      requireString(contentType, 'contentType');
+
+      if (!Number.isInteger(contentLength) || contentLength <= 0) {
+        throw new InvalidPresignRequestError('\'contentLength\' is required and must be a positive integer');
+      }
+      if (config.maxContentLength !== undefined && contentLength > config.maxContentLength) {
+        throw new InvalidPresignRequestError(
+          `'contentLength' exceeds the maximum of ${config.maxContentLength} bytes`);
+      }
+
+      // Refused rather than clamped: a caller that asked for a day-long URL and
+      // silently received a fifteen-minute one finds out when the upload fails.
+      if (expiresIn !== undefined) {
+        if (!Number.isInteger(expiresIn) || expiresIn <= 0) {
+          throw new InvalidPresignRequestError('\'expiresIn\' must be a positive integer number of seconds');
+        }
+        if (expiresIn > config.maxExpiresIn) {
+          throw new InvalidPresignRequestError(
+            `'expiresIn' exceeds the maximum of ${config.maxExpiresIn} seconds`);
+        }
+      }
+
+      const entries = requireStringValues(metadata);
+
+      const basePath = decodeURIComponent(requestPath(req).substring(1));
+      const bucket = req.seshat.bucket;
+
+      return bucket.presignUpload({
+        // Mirrors how MultipartUpload derives object names, so presigning
+        // against POST /attachments/ lands where a multipart upload would.
+        name: path.join(basePath, filename as string),
+        contentType: contentType as string,
+        contentLength: contentLength as number,
+        expiresIn: expiresIn ?? config.defaultExpiresIn,
+        metadata: entries,
+      });
+    },
+  };
+};
+
+/**
+ * For backward compatibility when actions did not have parameters
+ */
+export const PresignUploadAction = PresignUploadActionFactory();

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -36,3 +36,13 @@ export class VirusDetectedError extends ObjectTransformerError {
 }
 
 export class UnknownActionError extends SeshatError {}
+
+/**
+ * 501 rather than 4xx on purpose: every case that raises this - a backend with
+ * no signing authority, a bucket carrying content transformers, an SSE-C
+ * bucket - is a fact about how the server is configured, not a mistake the
+ * client made or can correct by asking differently.
+ */
+export class PresignNotSupportedError extends SeshatError {
+  httpCode = 501;
+}

--- a/src/gcs/bucket.ts
+++ b/src/gcs/bucket.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream';
 import AbstractBucket from '../abstract-bucket.js';
-import type { BucketConfig, ListOptions, SeshatObject, SeshatObjectMeta } from '../types.js';
+import type { BucketConfig, ListOptions, PresignedUpload, SeshatObject, SeshatObjectMeta } from '../types.js';
 import { GCSObject, GCSObjectMeta } from './object.js';
 import { type GetFilesOptions, Storage } from '@google-cloud/storage';
 
@@ -138,6 +138,47 @@ export class GCSBucket extends AbstractBucket {
    *
    * We therefore need helpers to include/remove this prefix from object Keys
    */
+
+  protected async _presignUpload(meta: SeshatObjectMeta, expiresIn: number): Promise<PresignedUpload> {
+    // No SSE-C guard needed here: the constructor already refuses a bucket
+    // configured with encryption.
+    const { contentType, contentLength, name, ...rest } = meta;
+
+    const extensionHeaders: Record<string, string> = {
+      'content-length': String(contentLength),
+      ...Object.entries(rest).reduce((headers, [key, value]) => {
+        headers[`x-goog-meta-${key.toLowerCase()}`] = encodeURIComponent(
+          value?.toString ? value.toString() : value);
+        return headers;
+      }, {} as Record<string, string>),
+    };
+
+    const expiresAt = new Date(Date.now() + expiresIn * 1000);
+
+    const [url] = await this.client
+      .bucket(this.bucket)
+      .file(this.objectKey(name))
+      .getSignedUrl({
+        version: 'v4',
+        action: 'write',
+        expires: expiresAt.getTime(),
+        contentType,
+        extensionHeaders,
+      });
+
+    return {
+      url,
+      method: 'PUT',
+      // Unlike S3's signer, GCS keeps every signed header a header: the client
+      // has to replay all of them, metadata included.
+      headers: {
+        'content-type': contentType,
+        ...extensionHeaders,
+      },
+      name,
+      expiresAt,
+    };
+  }
 
   private objectKey(path?: string): string {
     return (this.prefix || '') + (path || '');

--- a/src/s3/bucket.ts
+++ b/src/s3/bucket.ts
@@ -3,20 +3,37 @@ import AbstractBucket from '../abstract-bucket.js';
 import type { BucketConfig, ListOptions, SeshatObject, SeshatObjectMeta } from '../types.js';
 import { S3Object } from './object.js';
 
-import { S3Client, HeadObjectCommand, ListObjectsV2Command, DeleteObjectCommand, GetObjectCommand, type ListObjectsV2CommandInput, type GetObjectCommandInput, type PutObjectCommandInput, type HeadObjectCommandInput } from '@aws-sdk/client-s3';
+import { S3Client, HeadObjectCommand, ListObjectsV2Command, DeleteObjectCommand, GetObjectCommand, PutObjectCommand, type ListObjectsV2CommandInput, type GetObjectCommandInput, type PutObjectCommandInput, type HeadObjectCommandInput } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
-import { ObjectNotFoundError, PrefixNotFoundError } from '../errors.js';
+import { ObjectNotFoundError, PresignNotSupportedError, PrefixNotFoundError } from '../errors.js';
+import type { PresignedUpload } from '../types.js';
 
 export interface S3BucketConfig extends BucketConfig {
   bucket: string,
   s3client: S3Client,
+  /**
+   * Client used to sign presigned upload URLs, when that has to differ from
+   * `s3client`.
+   *
+   * Two things can force them apart. A signature covers the Host header, so the
+   * URL must be signed against the address the *client* will reach - which is
+   * not the same as this process's address whenever storage sits behind a
+   * private network, as it does in most docker setups. And presigning requires
+   * a client built with `requestChecksumCalculation: 'WHEN_REQUIRED'`, which
+   * you may not want to impose on the client doing ordinary reads and writes.
+   *
+   * Against real S3 neither usually applies, and this can be left unset.
+   */
+  presignClient?: S3Client,
   prefix?: string
 }
 
 export class S3Bucket extends AbstractBucket {
 
   private s3client: S3Client;
+  private presignClient: S3Client;
   private bucket: string;
   private prefix?: string;
 
@@ -25,6 +42,7 @@ export class S3Bucket extends AbstractBucket {
   ) {
     super(config);
     this.s3client = config.s3client;
+    this.presignClient = config.presignClient || config.s3client;
     this.bucket = config.bucket;
     this.prefix = config.prefix;
   }
@@ -184,6 +202,83 @@ export class S3Bucket extends AbstractBucket {
    *
    * We therefore need helpers to include/remove this prefix from object Keys
    */
+
+  protected async _presignUpload(meta: SeshatObjectMeta, expiresIn: number): Promise<PresignedUpload> {
+    if (this.config.encryption) {
+      throw new PresignNotSupportedError(
+        'Cannot presign uploads on an SSE-C encrypted bucket: the client would have to be ' +
+        'given the encryption key.');
+    }
+
+    await this.ensurePresignableClient();
+
+    const { contentType, contentLength, name, ...rest } = meta;
+    // Encoded as _put() encodes it, so custom metadata reads back the same
+    // whichever way the object arrived. Unlike _put() this drops contentLength,
+    // which S3 carries as a standard field on a signed PUT.
+    const metadata = Object.entries(rest)
+      .reduce((obj, [key, value]) => {
+        obj[key] = encodeURIComponent(value?.toString ? value.toString() : value);
+        return obj;
+      }, {} as {[key: string]: string});
+
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: this.objectKey(name),
+      ContentType: contentType,
+      ContentLength: contentLength,
+      Metadata: metadata,
+    });
+
+    const url = await getSignedUrl(this.presignClient, command, {
+      expiresIn,
+      // Without this the signature covers only content-length and host, leaving
+      // the client free to declare any content-type it likes - which would let
+      // it walk straight past a content-type policy that had already approved
+      // the request.
+      signableHeaders: new Set(['content-type']),
+    });
+
+    return {
+      url,
+      method: 'PUT',
+      // Only what the client has to replay. The x-amz-meta-* entries are hoisted
+      // into the URL's query string by the signer and are covered by the
+      // signature there, so repeating them as headers would be noise at best.
+      headers: {
+        'content-type': contentType,
+        'content-length': String(contentLength),
+      },
+      name,
+      expiresAt: new Date(Date.now() + expiresIn * 1000),
+    };
+  }
+
+  /**
+   * The SDK defaults `requestChecksumCalculation` to WHEN_SUPPORTED, which makes
+   * it compute a CRC32 over the request body and hoist it into the signed URL.
+   * At signing time that body is empty, so the URL ends up carrying the checksum
+   * of nothing and S3 rejects the real upload when it arrives.
+   *
+   * It is a client-construction setting and the client is handed to us already
+   * built, so the most we can do is refuse early. Failing here - with something
+   * that names the fix - beats handing back a URL that dies at the far end, in
+   * someone else's process, against a checksum they never asked for.
+   */
+  private async ensurePresignableClient(): Promise<void> {
+    const configured = (this.presignClient.config as { requestChecksumCalculation?: unknown }).requestChecksumCalculation;
+    const value = typeof configured === 'function'
+      ? await (configured as () => Promise<string>)()
+      : configured;
+
+    if (value !== 'WHEN_REQUIRED') {
+      throw new PresignNotSupportedError(
+        'Cannot presign uploads with this S3Client: it computes request checksums ' +
+        `(requestChecksumCalculation: '${value}'), which the signer binds into the URL as a ` +
+        'checksum of an empty body, so the upload would be rejected. Construct the client with ' +
+        'requestChecksumCalculation: \'WHEN_REQUIRED\' to presign.');
+    }
+  }
 
   private objectKey(path?: string): string {
     return (this.prefix || '') + (path || '');

--- a/src/transformers/secure-rename.ts
+++ b/src/transformers/secure-rename.ts
@@ -43,6 +43,10 @@ export class SecureRename implements ObjectTransformer {
   type: ObjectTransformerType = 'Duplex';
 
   async transform(stream: Readable, meta: SeshatObjectMeta, mode: ObjectTransformerMode): Promise<ObjectTransformerOutput> {
+    return { stream, meta: await this.transformMeta(meta, mode) };
+  }
+
+  async transformMeta(meta: SeshatObjectMeta, mode: ObjectTransformerMode): Promise<SeshatObjectMeta> {
     if (mode === 'Ingress') {
       const generated = await this.nameGenerator();
       const info = path.parse(meta.name);
@@ -54,15 +58,18 @@ export class SecureRename implements ObjectTransformer {
         name,
       };
 
-      return { meta: metadata, stream };
+      return metadata;
     } else {
       const metadata: SeshatObjectMeta = {
         ...meta,
-        name: meta.originalname,
+        // Falls back to the stored name: an object written straight to the
+        // backend without an `originalname` (a presigned upload whose metadata
+        // was dropped, say) would otherwise come back with name undefined.
+        name: meta.originalname ?? meta.name,
       };
       delete metadata.originalname;
 
-      return { stream, meta: metadata };
+      return metadata;
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export interface Bucket extends BucketEmitter {
   delete(path: string): Promise<void>;
   list(prefix?: string, options?: ListOptions): Promise<SeshatObjectMeta[]>;
   mkdir(prefix: string): Promise<void>;
+  presignUpload(request: PresignedUploadRequest): Promise<PresignedUpload>;
 }
 
 export interface BucketPolicy {
@@ -95,6 +96,67 @@ export interface ObjectTransformer {
 
   transform(stream: Readable, meta: SeshatObjectMeta, mode: ObjectTransformerMode): Promise<ObjectTransformerOutput>;
 
+}
+
+/**
+ * Implemented by transformers that only rewrite metadata and never touch the
+ * bytes. Presence of `transformMeta` is itself the declaration - there is no
+ * companion boolean that could drift out of sync with the behaviour.
+ *
+ * This matters for presigned uploads, where the bytes never reach Seshat: a
+ * transformer that rewrites content cannot run, so presigning refuses rather
+ * than silently dropping it. A transformer that does not implement this is
+ * therefore assumed to touch content, which is the safe default for anything
+ * written before this interface existed.
+ */
+export interface ObjectMetaTransformer {
+  transformMeta(meta: SeshatObjectMeta, mode: ObjectTransformerMode): Promise<SeshatObjectMeta>;
+}
+
+export const isMetaTransformer = (
+  transformer: ObjectTransformer,
+): transformer is ObjectTransformer & ObjectMetaTransformer => {
+  return typeof (transformer as Partial<ObjectMetaTransformer>).transformMeta === 'function';
+};
+
+/**
+ * Applied when a caller reaches `Bucket.presignUpload` directly without naming
+ * a lifetime. Requests arriving through the presign-upload action carry one
+ * already, defaulted and bounded by that action's own options.
+ */
+export const DefaultPresignExpiresIn = 900;
+
+export type PresignedUploadRequest = {
+  /** Object name, relative to the bucket and to its static prefix, if any. */
+  name: string
+  contentType: string
+  /** Bound into the signature: the upload must match it exactly. */
+  contentLength: number
+  /**
+   * Seconds. Defaulted and bounded by the presign-upload action; omitted here,
+   * it falls back to `DefaultPresignExpiresIn`.
+   */
+  expiresIn?: number
+  /**
+   * Extra metadata entries, stored as backend custom metadata. Entries never
+   * override `name`, `contentType` or `contentLength`.
+   */
+  metadata?: Record<string, string>
+}
+
+export type PresignedUpload = {
+  /** Treat as a bearer credential: whoever holds it can write this one object. */
+  url: string
+  method: 'PUT'
+  /**
+   * Headers the client must send verbatim. These are part of the signature, so
+   * omitting or altering one makes the backend reject the upload. Anything the
+   * backend carries in the URL itself is deliberately not repeated here.
+   */
+  headers: Record<string, string>
+  /** Final object name, after name transformers such as SecureRename. */
+  name: string
+  expiresAt: Date
 }
 
 export interface Action {

--- a/tests/presign-upload.spec.ts
+++ b/tests/presign-upload.spec.ts
@@ -1,0 +1,475 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { type Storage } from '@google-cloud/storage';
+import { Readable } from 'stream';
+
+import * as chai from 'chai';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+import { GCSBucket, LocalBucket, S3Bucket } from '../src/index.js';
+import { PresignNotSupportedError } from '../src/errors.js';
+import { InvalidPresignRequestError, PresignUploadActionFactory } from '../src/actions/index.js';
+import { SecureRename } from '../src/transformers/index.js';
+import type {
+  ObjectTransformer, ObjectTransformerOutput, SeshatObjectMeta,
+} from '../src/types.js';
+
+/**
+ * A content transformer: no transformMeta, so presigning must refuse it.
+ */
+class DummyContentTransformer implements ObjectTransformer {
+  type: 'Ingress' = 'Ingress';
+  async transform(stream: Readable, meta: SeshatObjectMeta): Promise<ObjectTransformerOutput> {
+    return { stream, meta };
+  }
+}
+
+/**
+ * Static credentials and WHEN_REQUIRED, which is what presigning demands.
+ * aws-sdk-client-mock is deliberately not used here: getSignedUrl signs locally
+ * from the client's config and never reaches client.send(), so a mocked client
+ * sees nothing. Asserting on the URL the signer produces is the real test.
+ */
+const presignableClient = () => new S3Client({
+  region: 'eu-west1',
+  credentials: { accessKeyId: 'access-key', secretAccessKey: 'secret-key' },
+  endpoint: 'http://127.0.0.1:9000',
+  forcePathStyle: true,
+  requestChecksumCalculation: 'WHEN_REQUIRED',
+});
+
+describe('presigned uploads', () => {
+
+  const request = {
+    name: 'folder/report.pdf',
+    contentType: 'application/pdf',
+    contentLength: 4823910,
+    expiresIn: 900,
+  };
+
+  describe('S3Bucket', () => {
+
+    let bucket: S3Bucket;
+    beforeEach(() => {
+      bucket = new S3Bucket({ bucket: 'seshat-bucket', s3client: presignableClient() });
+    });
+
+    it('signs a PUT url for the object', async () => {
+      const presigned = await bucket.presignUpload(request);
+
+      expect(presigned.method).to.equal('PUT');
+      expect(presigned.name).to.equal('folder/report.pdf');
+      const url = new URL(presigned.url);
+      expect(url.pathname).to.equal('/seshat-bucket/folder/report.pdf');
+      expect(url.searchParams.get('X-Amz-Expires')).to.equal('900');
+      expect(url.searchParams.get('X-Amz-Signature')).to.be.a('string');
+    });
+
+    // Without signableHeaders the signature covers content-length and host only,
+    // which would let a caller declare any content-type it liked.
+    it('binds content-type and content-length into the signature', async () => {
+      const presigned = await bucket.presignUpload(request);
+
+      const signed = decodeURIComponent(
+        new URL(presigned.url).searchParams.get('X-Amz-SignedHeaders') as string).split(';');
+      expect(signed).to.include('content-type');
+      expect(signed).to.include('content-length');
+    });
+
+    // The SDK defaults to computing a request checksum, which at signing time is
+    // taken over an empty body and would make the real upload fail.
+    it('does not bind a checksum of the empty signing-time body', async () => {
+      const presigned = await bucket.presignUpload(request);
+
+      expect(new URL(presigned.url).searchParams.get('x-amz-checksum-crc32')).to.equal(null);
+    });
+
+    it('refuses a client that would compute request checksums', async () => {
+      const checksumming = new S3Bucket({
+        bucket: 'seshat-bucket',
+        s3client: new S3Client({
+          region: 'eu-west1',
+          credentials: { accessKeyId: 'access-key', secretAccessKey: 'secret-key' },
+        }),
+      });
+
+      await expect(checksumming.presignUpload(request))
+        .to.be.rejectedWith(PresignNotSupportedError, /requestChecksumCalculation/);
+    });
+
+    it('refuses an SSE-C encrypted bucket', async () => {
+      const encrypted = new S3Bucket({
+        bucket: 'seshat-bucket',
+        s3client: presignableClient(),
+        encryption: { alg: 'AES256', key: 'a'.repeat(32) },
+      });
+
+      await expect(encrypted.presignUpload(request))
+        .to.be.rejectedWith(PresignNotSupportedError, /encryption key/);
+    });
+
+    it('returns only the headers the client must replay', async () => {
+      const presigned = await bucket.presignUpload({ ...request, metadata: { ttl: '3600' } });
+
+      expect(presigned.headers).to.have.keys(['content-type', 'content-length']);
+      expect(presigned.headers['content-length']).to.equal('4823910');
+      // metadata rides in the query string, already covered by the signature
+      expect(new URL(presigned.url).searchParams.get('x-amz-meta-ttl')).to.equal('3600');
+    });
+
+    // Custom metadata is caller-supplied. Landing it on top of the derived
+    // fields would let `name` move the object key out of the path the request
+    // addressed, and `contentLength` replace the value the action just checked
+    // against its ceiling.
+    it('does not let custom metadata override the derived fields', async () => {
+      const presigned = await bucket.presignUpload({
+        ...request,
+        metadata: {
+          name: '../../escaped.pdf',
+          contentType: 'text/html',
+          contentLength: '999999999',
+        } as unknown as Record<string, string>,
+      });
+
+      expect(presigned.name).to.equal('folder/report.pdf');
+      expect(presigned.headers['content-type']).to.equal('application/pdf');
+      expect(presigned.headers['content-length']).to.equal('4823910');
+      expect(new URL(presigned.url).pathname).to.equal('/seshat-bucket/folder/report.pdf');
+    });
+
+    // expiresIn is optional on PresignedUploadRequest, so a direct caller may
+    // omit it. Left uncovered that produced an Invalid Date expiresAt and let
+    // the AWS SDK apply its own 3600 rather than Seshat's default.
+    it('falls back to the default lifetime when none is given', async () => {
+      const presigned = await bucket.presignUpload({
+        name: 'folder/report.pdf', contentType: 'application/pdf', contentLength: 4823910,
+      });
+
+      expect(new URL(presigned.url).searchParams.get('X-Amz-Expires')).to.equal('900');
+      expect(Number.isNaN(presigned.expiresAt.getTime())).to.equal(false);
+    });
+  });
+
+  describe('GCSBucket', () => {
+
+    /**
+     * The GCS client signs over the network-free path too, but through a File
+     * handle rather than a command object, so the seam worth pinning is the
+     * options this bucket hands getSignedUrl - and the headers it tells the
+     * client to replay, which unlike S3 must carry the metadata.
+     */
+    let getSignedUrl: sinon.SinonStub;
+    let file: sinon.SinonStub;
+    let client: Storage;
+
+    const signedOptions = () => getSignedUrl.firstCall.args[0];
+
+    const gcsBucket = (config: Record<string, unknown> = {}) => new GCSBucket({
+      bucket: 'seshat-bucket', client, ...config,
+    });
+
+    beforeEach(() => {
+      getSignedUrl = sinon.stub().resolves(['https://storage.googleapis.com/signed-url']);
+      file = sinon.stub().returns({ getSignedUrl });
+      client = { bucket: sinon.stub().returns({ file }) } as unknown as Storage;
+    });
+
+    it('signs a write url for the object', async () => {
+      const presigned = await gcsBucket().presignUpload(request);
+
+      expect(client.bucket).to.have.been.calledWith('seshat-bucket');
+      expect(file).to.have.been.calledWith('folder/report.pdf');
+      expect(signedOptions()).to.include({
+        version: 'v4',
+        action: 'write',
+        contentType: 'application/pdf',
+      });
+      expect(presigned.url).to.equal('https://storage.googleapis.com/signed-url');
+      expect(presigned.method).to.equal('PUT');
+      expect(presigned.name).to.equal('folder/report.pdf');
+    });
+
+    it('signs against the bucket prefix', async () => {
+      await gcsBucket({ prefix: 'tenant-a/' }).presignUpload(request);
+
+      expect(file).to.have.been.calledWith('tenant-a/folder/report.pdf');
+    });
+
+    it('binds content-length and custom metadata as extension headers', async () => {
+      await gcsBucket().presignUpload({ ...request, metadata: { ttl: '3600' } });
+
+      expect(signedOptions().extensionHeaders).to.deep.equal({
+        'content-length': '4823910',
+        'x-goog-meta-ttl': '3600',
+      });
+    });
+
+    // Unlike S3's signer, GCS keeps every signed header a header, so the client
+    // has to replay the metadata too - dropping it would fail the signature.
+    it('returns every signed header for the client to replay', async () => {
+      const presigned = await gcsBucket().presignUpload({ ...request, metadata: { ttl: '3600' } });
+
+      expect(presigned.headers).to.deep.equal({
+        'content-type': 'application/pdf',
+        'content-length': '4823910',
+        'x-goog-meta-ttl': '3600',
+      });
+    });
+
+    it('expires the url at the requested lifetime', async () => {
+      const presigned = await gcsBucket().presignUpload({ ...request, expiresIn: 600 });
+
+      expect(signedOptions().expires).to.equal(presigned.expiresAt.getTime());
+      expect(presigned.expiresAt.getTime() - Date.now()).to.be.closeTo(600 * 1000, 5000);
+    });
+
+    it('falls back to the default lifetime when none is given', async () => {
+      const presigned = await gcsBucket().presignUpload({
+        name: 'folder/report.pdf', contentType: 'application/pdf', contentLength: 4823910,
+      });
+
+      expect(Number.isNaN(presigned.expiresAt.getTime())).to.equal(false);
+      expect(presigned.expiresAt.getTime() - Date.now()).to.be.closeTo(900 * 1000, 5000);
+    });
+
+    it('applies name transformers to the object being signed', async () => {
+      const presigned = await gcsBucket({ transformers: [new SecureRename()] }).presignUpload(request);
+
+      expect(presigned.name).to.match(/^folder\/.+\.pdf$/);
+      expect(file).to.have.been.calledWith(presigned.name);
+      // the user-facing name must survive as metadata, or Egress rename breaks
+      expect(signedOptions().extensionHeaders['x-goog-meta-originalname'])
+        .to.equal('folder%2Freport.pdf');
+    });
+
+    it('does not let custom metadata override the derived fields', async () => {
+      const presigned = await gcsBucket().presignUpload({
+        ...request,
+        metadata: {
+          name: '../../escaped.pdf',
+          contentType: 'text/html',
+          contentLength: '999999999',
+        } as unknown as Record<string, string>,
+      });
+
+      expect(presigned.name).to.equal('folder/report.pdf');
+      expect(file).to.have.been.calledWith('folder/report.pdf');
+      expect(signedOptions().contentType).to.equal('application/pdf');
+      expect(signedOptions().extensionHeaders['content-length']).to.equal('4823910');
+    });
+
+    it('refuses a bucket carrying a content transformer', async () => {
+      await expect(gcsBucket({ transformers: [new DummyContentTransformer()] }).presignUpload(request))
+        .to.be.rejectedWith(PresignNotSupportedError, /DummyContentTransformer/);
+      // eslint-disable-next-line no-unused-expressions
+      expect(getSignedUrl).to.not.have.been.called;
+    });
+  });
+
+  describe('policies and transformers', () => {
+
+    it('applies name transformers to the object being signed', async () => {
+      const bucket = new S3Bucket({
+        bucket: 'seshat-bucket',
+        s3client: presignableClient(),
+        transformers: [new SecureRename()],
+      });
+
+      const presigned = await bucket.presignUpload(request);
+
+      expect(presigned.name).to.not.equal('folder/report.pdf');
+      expect(presigned.name).to.match(/^folder\/.+\.pdf$/);
+      // the user-facing name must survive as metadata, or Egress rename breaks
+      expect(new URL(presigned.url).searchParams.get('x-amz-meta-originalname'))
+        .to.equal('folder%2Freport.pdf');
+    });
+
+    it('runs policies against the pre-rename meta, as put() does', async () => {
+      const policy = {
+        head: sinon.stub().resolves(), get: sinon.stub().resolves(),
+        put: sinon.stub().resolves(), delete: sinon.stub().resolves(),
+        list: sinon.stub().resolves(), mkdir: sinon.stub().resolves(),
+      };
+      const bucket = new S3Bucket({
+        bucket: 'seshat-bucket',
+        s3client: presignableClient(),
+        policies: [policy],
+        transformers: [new SecureRename()],
+      });
+
+      await bucket.presignUpload(request);
+
+      // eslint-disable-next-line no-unused-expressions
+      expect(policy.put).to.have.been.calledOnce;
+      expect(policy.put.firstCall.args[0]).to.include({
+        name: 'folder/report.pdf',
+        contentType: 'application/pdf',
+        contentLength: 4823910,
+      });
+    });
+
+    it('refuses a bucket carrying a content transformer', async () => {
+      const bucket = new S3Bucket({
+        bucket: 'seshat-bucket',
+        s3client: presignableClient(),
+        transformers: [new DummyContentTransformer()],
+      });
+
+      await expect(bucket.presignUpload(request))
+        .to.be.rejectedWith(PresignNotSupportedError, /DummyContentTransformer/);
+    });
+  });
+
+  describe('LocalBucket', () => {
+
+    it('refuses: a filesystem has no signing authority', async () => {
+      const bucket = new LocalBucket({ path: import.meta.dirname });
+
+      await expect(bucket.presignUpload(request))
+        .to.be.rejectedWith(PresignNotSupportedError, /does not support presigned uploads/);
+    });
+  });
+
+  describe('the presign-upload action', () => {
+
+    let bucket: { presignUpload: sinon.SinonStub };
+    const req = (body: any, path = '/') => ({ path, body, seshat: { bucket } }) as any;
+
+    beforeEach(() => {
+      bucket = { presignUpload: sinon.stub().resolves({}) };
+    });
+
+    it('passes a valid request through to the bucket', async () => {
+      const action = PresignUploadActionFactory();
+
+      await action.run(req({ filename: 'r.pdf', contentType: 'application/pdf', contentLength: 31 }, '/docs/'));
+
+      expect(bucket.presignUpload.firstCall.args[0]).to.deep.include({
+        name: 'docs/r.pdf',
+        contentType: 'application/pdf',
+        contentLength: 31,
+        expiresIn: 900,
+      });
+    });
+
+    // The same Express 5 mount-path handling the routers needed: '/docs//'
+    // must address docs/, not a nested empty segment.
+    it('normalises a doubled slash after the mount path', async () => {
+      const action = PresignUploadActionFactory();
+
+      await action.run(req({ filename: 'r.pdf', contentType: 'application/pdf', contentLength: 31 }, '//'));
+
+      expect(bucket.presignUpload.firstCall.args[0].name).to.equal('r.pdf');
+    });
+
+    const rejects = (body: any, match: RegExp) => async () => {
+      const action = PresignUploadActionFactory();
+      await expect(action.run(req(body))).to.be.rejectedWith(InvalidPresignRequestError, match);
+    };
+
+    it('rejects a missing filename', rejects(
+      { contentType: 'application/pdf', contentLength: 1 }, /filename/));
+
+    it('rejects a missing contentType', rejects(
+      { filename: 'r.pdf', contentLength: 1 }, /contentType/));
+
+    it('rejects a missing contentLength', rejects(
+      { filename: 'r.pdf', contentType: 'application/pdf' }, /contentLength/));
+
+    it('rejects a zero contentLength', rejects(
+      { filename: 'r.pdf', contentType: 'application/pdf', contentLength: 0 }, /contentLength/));
+
+    it('rejects a non-integer contentLength', rejects(
+      { filename: 'r.pdf', contentType: 'application/pdf', contentLength: 1.5 }, /contentLength/));
+
+    it('rejects a contentLength above the configured ceiling', async () => {
+      const action = PresignUploadActionFactory({
+        defaultExpiresIn: 900, maxExpiresIn: 3600, maxContentLength: 1024,
+      });
+
+      await expect(action.run(req({ filename: 'r.pdf', contentType: 'application/pdf', contentLength: 2048 })))
+        .to.be.rejectedWith(InvalidPresignRequestError, /maximum of 1024 bytes/);
+    });
+
+    // Refused, not silently shortened: a caller that asked for a day-long URL
+    // should learn it did not get one.
+    it('rejects rather than clamps an over-long expiresIn', rejects(
+      { filename: 'r.pdf', contentType: 'application/pdf', contentLength: 1, expiresIn: 86400 },
+      /maximum of 3600 seconds/));
+
+    it('rejects non-object metadata', rejects(
+      { filename: 'r.pdf', contentType: 'application/pdf', contentLength: 1, metadata: 'nope' }, /metadata/));
+
+    it('rejects array metadata', rejects(
+      { filename: 'r.pdf', contentType: 'application/pdf', contentLength: 1, metadata: ['nope'] }, /metadata/));
+
+    it('rejects null metadata', rejects(
+      { filename: 'r.pdf', contentType: 'application/pdf', contentLength: 1, metadata: null }, /metadata/));
+
+    // Backends stringify metadata with `.toString()`, which a null answers with
+    // a TypeError - a 500 on input the client controls, where the contract the
+    // error message states calls for a 400.
+    it('rejects a null metadata value', rejects(
+      { filename: 'r.pdf', contentType: 'application/pdf', contentLength: 1, metadata: { foo: null } },
+      /'metadata\.foo' must be a string, got null/));
+
+    it('rejects a non-string metadata value', rejects(
+      { filename: 'r.pdf', contentType: 'application/pdf', contentLength: 1, metadata: { foo: { bar: 1 } } },
+      /'metadata\.foo' must be a string, got object/));
+
+    it('passes string metadata through', async () => {
+      const action = PresignUploadActionFactory();
+
+      await action.run(req({
+        filename: 'r.pdf', contentType: 'application/pdf', contentLength: 31, metadata: { ttl: '3600' },
+      }));
+
+      expect(bucket.presignUpload.firstCall.args[0].metadata).to.deep.equal({ ttl: '3600' });
+    });
+  });
+
+  describe('SecureRename.transformMeta', () => {
+
+    // Guards the refactor: transform() must stay a thin wrapper over transformMeta.
+    it('agrees with transform() on Ingress', async () => {
+      const rename = new SecureRename({ nameGenerator: async () => 'fixed-name' });
+      const meta: SeshatObjectMeta = { name: 'a/b.pdf', contentType: 'application/pdf' };
+
+      const viaTransform = await rename.transform(Readable.from(['x']), meta, 'Ingress');
+      const viaMeta = await rename.transformMeta(meta, 'Ingress');
+
+      expect(viaMeta).to.deep.equal(viaTransform.meta);
+      expect(viaMeta.name).to.equal('a/fixed-name.pdf');
+      expect(viaMeta.originalname).to.equal('a/b.pdf');
+    });
+
+    it('agrees with transform() on Egress', async () => {
+      const rename = new SecureRename();
+      const meta: SeshatObjectMeta = {
+        name: 'a/fixed-name.pdf', contentType: 'application/pdf', originalname: 'a/b.pdf',
+      };
+
+      const viaTransform = await rename.transform(Readable.from(['x']), meta, 'Egress');
+      const viaMeta = await rename.transformMeta(meta, 'Egress');
+
+      expect(viaMeta).to.deep.equal(viaTransform.meta);
+      expect(viaMeta.name).to.equal('a/b.pdf');
+      expect(viaMeta.originalname).to.equal(undefined);
+    });
+
+    // A presigned upload whose metadata never made it would otherwise come back
+    // from Egress with name undefined.
+    it('keeps the stored name when originalname is absent', async () => {
+      const rename = new SecureRename();
+      const meta: SeshatObjectMeta = { name: 'a/fixed-name.pdf', contentType: 'application/pdf' };
+
+      const result = await rename.transformMeta(meta, 'Egress');
+
+      expect(result.name).to.equal('a/fixed-name.pdf');
+    });
+  });
+});


### PR DESCRIPTION
Implements `PRESIGNED_URL_PLAN.md`. A new `presign-upload` action hands the caller a short-lived signed URL it PUTs the bytes to directly, so they never pass through Seshat.

Per your call, `Bucket.presignUpload` is **required** and this targets **3.0.0 GA** — the interface addition rides along in an already-breaking release rather than violating semver in a minor.

## Review findings that changed the plan

I verified the risky claims against the SDK rather than taking them on trust. Four would have caused real failures:

**1. The AWS SDK silently breaks presigned uploads.** By default it binds `x-amz-checksum-crc32=AAAAAA==` into the URL — the CRC32 of an **empty** body, since there is no body at signing time. Every real upload would be rejected. It is a client-construction setting and the client is injected, so `S3Bucket` detects it and refuses with a message naming the fix. A unit test asserting "a URL was produced" passes happily; only the round trip catches it.

**2. §7.2's central security claim was false.** Signed headers are `content-length;host` — **content-type was not bound**, so a caller could declare any type and walk past the policy that had just approved the request. Fixed with `signableHeaders`.

**3. Metadata binding works, but not as §5.1 described.** `x-amz-meta-*` is hoisted into the query string, so it *is* covered by the signature — but must not be handed back for the client to replay.

**4. §10.1's S3 test strategy could not work.** `aws-sdk-client-mock` does not intercept `getSignedUrl` (measured: 0 calls while a URL was still produced). Tests use static credentials and assert on the URL's query parameters.

Also: `SecureRename` on Egress does `name: meta.originalname` then deletes the field, so a missing `originalname` yields `name: undefined`, not merely a wrong filename — now guarded with a fallback.

## Discovered while testing

**`presignClient`.** A signature covers the `Host` header, so a URL must name an address its *holder* can reach — not this process's address, whenever storage sits on a private network. `S3BucketConfig` gains an optional `presignClient` for that split.

**minio was never reachable from outside the compose network.** The published port pointed at 9000 while minio listens on 443, so `9000:9000` mapped to nothing. Fixed, which is what lets the round trip run in CI.

**Pre-existing bug fixed.** `mkdir`, `cleanup-ttl` and `download-archive` still derived paths from raw `req.path`, carrying the same Express 5 mount-path bug fixed in the routers last week — my earlier fix covered the routers but missed the actions.

## Verification

- build, lint, **153 unit tests**
- **webspicy: 31 spec files, 284 assertions, 0 failures**, including a postcondition that presigns, PUTs real bytes at the signed URL, and reads the object back asserting content equality — the only test that proves the signature is actually correct

## Deliberately not done

`§13.1` (GCS `signBlob` permission on Klaro's service account) and `§13.2` (whether GCS V4 enforces a signed `content-length`) remain open — both need a real GCS project, not fake-gcs-server. GCS is covered at unit level only, as the plan anticipated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)