### PR TITLE
Stop sending a Cache-Control header by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,24 @@ means in practice.
   resolved before the directory existed and turned any failure into an
   unhandled rejection instead of an error the caller could catch.
 
+* `RetrieveObjects` no longer sends a `Cache-Control` header by default,
+  restoring the pre-2.9.0 behaviour. 2.9.0 introduced the header along with a
+  `private, max-age=86400, must-revalidate` default, which silently made every
+  object fresh for 24 hours on the client: an object overwritten at the same
+  URL could be served stale for a full day, with no request reaching Seshat.
+  Seshat cannot assume a freshness lifetime on the bucket's behalf, so it goes
+  back to relying on `Last-Modified`/`ETag` revalidation. The feature itself
+  stays — set `headers.cacheControl` to opt in:
+
+  ```ts
+  RetrieveObjects({
+    headers: { cacheControl: 'private, max-age=86400, must-revalidate' },
+  })
+  ```
+
+  Deployments that upgraded to 2.9.0 and want to keep the header must now
+  configure it explicitly. See `examples/cacheControl.ts`.
+
 * Dependencies upgraded across the board, including @google-cloud/storage 7,
   sharp 0.35, mime-types 3 and body-parser 2. `npm audit` goes from 46
   findings (3 critical) to 3, all of them dev-only.

--- a/examples/cacheControl.ts
+++ b/examples/cacheControl.ts
@@ -2,13 +2,26 @@ import { type Express } from 'express';
 import { createApp, DeleteObjects, LocalBucket, MultipartUpload, RetrieveObjects } from '../src/index.js';
 
 /**
- * This simple example shows how to override the default
- * Cache-Control header on RetrieveObjects.
+ * This simple example shows how to set a Cache-Control header on
+ * RetrieveObjects. Seshat sends none by default.
  */
 export default (expressApp: Express, seshatRootDir: string) => {
 
   expressApp.use('/default-cache', createApp({
     bucket: new LocalBucket({ path: seshatRootDir }),
+  }));
+
+  expressApp.use('/cached', createApp({
+    bucket: new LocalBucket({ path: seshatRootDir }),
+    routers: [
+      DeleteObjects(),
+      MultipartUpload(),
+      RetrieveObjects({
+        headers: {
+          cacheControl: 'private, max-age=86400, must-revalidate',
+        },
+      }),
+    ],
   }));
 
   expressApp.use('/no-cache', createApp({

--- a/formaldoc/config.rb
+++ b/formaldoc/config.rb
@@ -13,7 +13,7 @@ Webspicy::Configuration.new(Path.dir) do |c|
   c.postcondition ImageIsResized
   c.postcondition ExifMetadataIsPreserved
   c.postcondition IsValidZipFile
-  c.errcondition NoCacheControlHeader
+  c.postcondition NoCacheControlHeader
   c.postcondition Webspicy::Web::Specification::Post::LastModifiedCachingProtocol
   c.postcondition Webspicy::Web::Specification::Post::ETagCachingProtocol
 

--- a/formaldoc/support/postconditions/no_cache_control_header.rb
+++ b/formaldoc/support/postconditions/no_cache_control_header.rb
@@ -1,5 +1,5 @@
 class NoCacheControlHeader
-  include Webspicy::Specification::Err
+  include Webspicy::Specification::Post
 
   MATCH = /It does not set the Cache-Control header/
 

--- a/formaldoc/test-suite/use-cases/cache-control/configured.yml
+++ b/formaldoc/test-suite/use-cases/cache-control/configured.yml
@@ -1,26 +1,28 @@
 ---
   name: |-
-    GET /default-cache/{object}
+    GET /{strategy}/{object}
 
   url: |-
-    /default-cache/{object}
+    /{strategy}/{object}
 
   services:
   - method: |-
       GET
 
     description: |-
-      Allows retrieving a file, without any caching directive of its own
+      Allows retrieving a file, with the Cache-Control header configured on
+      RetrieveObjects
 
     preconditions:
       - An object with that name exists on the bucket
 
     postconditions:
       - (x) It supports the Last-Modified/If-Modified-Since caching protocol
-      - (x) It does not set the Cache-Control header
+      - ( ) It sets the Cache-Control header as expected
 
     input_schema: |-
       {
+        strategy: String
         object: String
       }
 
@@ -35,19 +37,23 @@
     examples:
 
       - description: |-
-          FOR: the object exists
+          FOR: It sets the Cache-Control header as expected
         params:
+          strategy: cached
           object: test.json
         expected:
           content_type: application/json
           status: 200
-
-    counterexamples:
+          headers:
+            Cache-Control: private, max-age=86400, must-revalidate
 
       - description: |-
-          FOR: the object does not exist
+          FOR: It sets the Cache-Control header as expected
         params:
-          object: unknown.json
+          strategy: no-cache
+          object: test.json
         expected:
           content_type: application/json
-          status: 404
+          status: 200
+          headers:
+            Cache-Control: no-cache

--- a/src/express/routers/retrieve-objects.ts
+++ b/src/express/routers/retrieve-objects.ts
@@ -24,7 +24,12 @@ export const DefaultConfig: RetrieveObjectConfig = {
   headers: {
     lastModified: true,
     etag: true,
-    cacheControl: 'private, max-age=86400, must-revalidate',
+    // No Cache-Control header is sent unless one is explicitly configured.
+    // Seshat serves objects that may be overwritten at the same URL, so it
+    // cannot assume any freshness lifetime on the client's behalf; it relies
+    // on Last-Modified/ETag revalidation instead. Set this to opt into
+    // caching, e.g. 'private, max-age=86400, must-revalidate'.
+    cacheControl: '',
   },
 };
 

--- a/tests/express/routers/retrieve-objects.spec.ts
+++ b/tests/express/routers/retrieve-objects.spec.ts
@@ -1,0 +1,61 @@
+import request from 'supertest';
+import { RetrieveObjects } from '../../../src/express/routers/index.js';
+import { getMockBucket } from '../../mocks/bucket.js';
+import { ExposeContext } from '../../../src/express/middlewares/context.js';
+import { Bucket } from '../../../src/types.js';
+
+import express, { Application } from 'express';
+
+describe('the retrieve-objects express router', () => {
+
+  let mockBucket: Bucket;
+
+  const appWith = (router): Application => {
+    const app = express();
+    app.use(ExposeContext({ bucket: mockBucket }));
+    app.use(router);
+    return app;
+  };
+
+  beforeEach(() => {
+    mockBucket = getMockBucket();
+  });
+
+  describe('the Cache-Control header', () => {
+
+    it('is not sent when used with default options', () => {
+      return request(appWith(RetrieveObjects()(mockBucket)))
+        .get('/tmp/file.txt')
+        .expect(200)
+        .expect((res) => {
+          if ('cache-control' in res.headers) {
+            throw new Error(`Unexpected Cache-Control: ${res.headers['cache-control']}`);
+          }
+        });
+    });
+
+    it('is sent when explicitly configured', () => {
+      const router = RetrieveObjects({
+        headers: { cacheControl: 'private, max-age=86400, must-revalidate' },
+      })(mockBucket);
+      return request(appWith(router))
+        .get('/tmp/file.txt')
+        .expect(200)
+        .expect('Cache-Control', 'private, max-age=86400, must-revalidate');
+    });
+
+    it('is not sent when explicitly configured with an empty value', () => {
+      const router = RetrieveObjects({ headers: { cacheControl: '' } })(mockBucket);
+      return request(appWith(router))
+        .get('/tmp/file.txt')
+        .expect(200)
+        .expect((res) => {
+          if ('cache-control' in res.headers) {
+            throw new Error(`Unexpected Cache-Control: ${res.headers['cache-control']}`);
+          }
+        });
+    });
+
+  });
+
+});


### PR DESCRIPTION
2.9.0 added Cache-Control support to RetrieveObjects and, in the same change, gave it a default of 'private, max-age=86400, must-revalidate'. Since createApp builds its default router stack with a bare RetrieveObjects(), that turned into a behaviour change for every deployment that had configured nothing: responses that previously carried no freshness directive at all suddenly declared themselves fresh for 24 hours.

The consequence is not theoretical. Seshat serves objects that can be overwritten at the same URL, and a client holding a fresh response does not revalidate - it does not issue a request at all. An object replaced through Seshat could therefore keep being served from browser cache for a full day, with the server having no way to know or intervene. Seshat cannot pick a freshness lifetime on the bucket's behalf, so the default goes back to relying on the Last-Modified/ETag revalidation it already sends.

The feature stays. headers.cacheControl is now empty by default and the existing truthiness guard omits the header; set it to any non-empty value to opt in, which is what deployments that adopted the 2.9.0 default now need to do explicitly.

On the formaldoc side, NoCacheControlHeader moves from an errcondition to a postcondition so it asserts absence on a 200 rather than only on error responses. That forces a spec split: webspicy runs a Ruby-backed postcondition against every example of a service, so the strategy that sends no header cannot share a service with the ones that do. default.yml is now scoped to /default-cache/{object}, and the configured strategies move to configured.yml.

Verified with the full webspicy suite: 0 failures. The 3 errors it reports are missing ImageMagick in the local environment, which CI installs.